### PR TITLE
Bug: force-directed-graph.ts emits the wrong value

### DIFF
--- a/src/app/d3/models/force-directed-graph.ts
+++ b/src/app/d3/models/force-directed-graph.ts
@@ -79,9 +79,7 @@ export class ForceDirectedGraph {
         );
 
       // Connecting the d3 ticker to an angular event emitter
-      this.simulation.on('tick', function () {
-        ticker.emit(this);
-      });
+      this.simulation.on('tick', () => ticker.emit(this.simulation));
 
       this.initNodes();
       this.initLinks();


### PR DESCRIPTION
It emits `this`, should emit `this.simulation`. Additionally, the `function()` notation apparently causes the code to not be type-checked. Otherwise, a type mismatch error would have been emitted!